### PR TITLE
Module SRCVERSION matching; Deb dependencies and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,12 @@
 # savedump
 
-TL;DR; A Python hack I put together that does its best to archive
-crash dumps and core dumps together with their required binaries
-and debug info in Linux.
+![](https://github.com/sdimitro/savedump/workflows/.github/workflows/main.yml/badge.svg)
+
+TL;DR; A Python script that creates a best-effort self-contained
+archive of a kernel crash dump or userland core dump. The archive
+contains the memory dump coupled together with any required
+binaries and debug information that it could find at the time it
+was invoked.
 
 ### Motivation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,26 @@ dumps. What it does lack though is proper tooling to capture a
 self-contained dump from one system to analyze it in another.
 This is what this utility is attempting to help with.
 
+### Installation
+
+Ensure you have the following dependencies:
+* Python 3.6 or newer
+* [libkdumpfile](https://github.com/ptesarik/libkdumpfile)
+* [drgn](https://github.com/osandov/drgn/)
+* [gdb](https://www.gnu.org/software/gdb/)
+
+Note that `libkdumpfile` and `drgn` are only needed for kernel
+crash dumps. If you only need `savedump` for userland core dumps
+then you only need `python3`. `gdb` is not a hard dependency
+either but it is recommeneded for accurate archival of shared
+objects in userland core dumps.
+
+Once all dependencies are installed clone this repo and
+run the following command from the root of the repo:
+```
+sudo python3 setup.py install
+```
+
 ### How do I use it?
 
 To capture a crash dump or a core dump:

--- a/debian/control
+++ b/debian/control
@@ -3,13 +3,7 @@ Section: misc
 Priority: optional
 Maintainer: Delphix Engineering <eng@delphix.com>
 Standards-Version: 4.1.2
-Build-Depends: debhelper (>= 9),
-               dh-python,
-               python3,
-               python3-distutils,
-               python3.6-dev,
-               zlib1g-dev
-Suggests: libkdumpfile, drgn
+Build-Depends: debhelper (>= 9), dh-python, python3
 
 Package: savedump
 Architecture: any


### PR DESCRIPTION
## README changes testing:

see the rendering here: https://github.com/sdimitro/savedump/tree/mod_srcvers_deb

## Module SRCVERSION testing:

Ran against a crash dump on dlpx-trunk:
```
$ sudo savedump /var/crash/202008281550/dump.202008281550
dump type: kernel crash dump
vmlinux found: /usr/lib/debug/boot/vmlinux-5.4.0-42-generic
found 72 relevant modules with their debug info...
warning: could not find the debug info of the following modules:
  crct10dif_pclmul, crc32_pclmul, ghash_clmulni_intel, aesni_intel, intel_rapl_perf, input_leds, i2c_piix4
compressing archive...done
archive created: sd-savedump.dcenter.archive-dump.202008281550.tar.gz
```

Then moved the archive to a different system and did the following tests.

[1] `run-pycrash.sh` and `run-sdb.sh` work as expected:
```
$ scp delphix@sd-savedump.dcenter:~/savedump/sd-savedump.dcenter.archive-dump.202008281550.tar.gz .
sd-savedump.dcenter.archive-dump.202008281550.tar.gz                                                                                               100%  440MB  99.7MB/s   00:04
$ tar xzf sd-savedump.dcenter.archive-dump.202008281550.tar.gz
$ cd sd-savedump.dcenter.archive-dump.202008281550
$ ./run-sdb.sh
sdb> ^D
$ ./run-pycrash.sh
Slick Debugger (sdb) initializing...
Loading tasks....... done. (468 tasks total)
Loading modules for 5.4.0-42-genericLoading /export/home/delphix/sd-savedump.dcenter.archive-dump.202008281550/usr/lib/debug/lib/modules/5.4.0-42-generic/kernel/drivers/target/iscsi/iscsi_target_mod.ko at 0xffffffffc101c000
...
Couldn't find module file for crct10dif_pclmul
Couldn't find module file for crc32_pclmul
Couldn't find module file for ghash_clmulni_intel
Couldn't find module file for aesni_intel
...
 done. (72 loaded, 7 failed)
Backtrace from crashing task (PID 8205):
#0  0xffffffffa99573cd in crash_setup_regs (oldregs=<optimized out>, newregs=<optimized out>) at /build/linux-hwe-5.4-huXhHV/linux-hwe-5.4-5.4.0/arch/x86/include/asm/kexec.h:99
...
#14 0xffffffffaa40008c in entry_SYSCALL_64 () at /build/linux-hwe-5.4-huXhHV/linux-hwe-5.4-5.4.0/arch/x86/entry/entry_64.S:175
The 'pyhelp' command will list the command extensions.
sdb>
```

[2] The hierarchy has the zfs/spl modules in the `extra` directory, which
is expected since we are matching based on srcversion, and everything else
under `kernel`:
```
$ tree usr/
usr/
└── lib
    └── debug
        └── lib
            └── modules
                └── 5.4.0-42-generic
                    ├── extra
                    │   ├── avl
                    │   │   └── zavl.ko
                   ... ...
                    │   ├── zfs
                    │   │   └── zfs.ko
                    │   └── zstd
                    │       └── zzstd.ko
                    └── kernel
                        ├── arch
                        │   └── x86
                        │       └── crypto
                        │           └── glue_helper.ko
                        ├── crypto
                        │   ├── async_tx
                        │   │   ├── async_memcpy.ko
                        │   │   ├── async_pq.ko
                       ... ... ...
```

## Linux-pkg testing:

Changed linux-pkg and added `savedump` into the package directory in this personal branch: https://github.com/sdimitro/linux-pkg/tree/savedump

Added as a dependency in delphix-platform to be included in appliance-build: https://github.com/sdimitro/delphix-platform/tree/savedump

Userland job that uses this savedump branch and the above linux-pkg branch: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/linux-pkg-build/job/master/job/userland/job/pre-push/634/execution/node/68/log/

ab-pre-push testing: http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/3941/flowGraphTable/

TBA